### PR TITLE
Added INS mode for waypoint navigation

### DIFF
--- a/KSP Navigation/NavUtilLib/GlobalV_DisplayData.cs
+++ b/KSP Navigation/NavUtilLib/GlobalV_DisplayData.cs
@@ -52,8 +52,9 @@ namespace NavUtilLib
 
 
 
-                if (var.FlightData.locDeviation > 10 && var.FlightData.locDeviation < 170 || var.FlightData.locDeviation < -10 && var.FlightData.locDeviation > -170)
+                if (var.FlightData.isINSMode() || var.FlightData.locDeviation > 10 && var.FlightData.locDeviation < 170 || var.FlightData.locDeviation < -10 && var.FlightData.locDeviation > -170) {
                     locFlag = true;
+                }
 
                 if (var.FlightData.locDeviation < -90 || var.FlightData.locDeviation > 90)
                 {
@@ -114,11 +115,11 @@ namespace NavUtilLib
                     else
                     {
                         fineLoc = false;
-
                         NavUtilLib.GlobalVariables.Materials.Instance.localizer.color = Color.magenta;
                         screen = NavUtilLib.TextWriter.addTextToRT(screen, locMode, new Vector2(380, screen.height - 570), NavUtilLib.GlobalVariables.Materials.Instance.whiteFont, 0.5f);
                     }
-
+                    
+                    
                     deviationCorrection = Mathf.Clamp(deviationCorrection, -0.234375f, 0.234375f);
 
 
@@ -129,14 +130,13 @@ namespace NavUtilLib
                     screen = NavUtilLib.Graphics.drawMovedImagePortion(var.Materials.Instance.flag, .34375f, .65625f, 0, 1, screen, new Vector2(.821875f, 0.2046875f), false);
                 }
 
-                if(locFlag || !fineLoc)
+                if(locFlag || !fineLoc || var.FlightData.isINSMode())
                     NavUtilLib.GlobalVariables.Materials.Instance.NDBneedle.color = Color.white;
-
 
                 screen = NavUtilLib.Graphics.drawMovedImage(var.Materials.Instance.overlay, screen, new Vector2(0, 0), false, false);
                 //marker beacons
                 //imageBox takes bottom x, 
-                if (var.FlightData.dme < 200000)
+                if ((var.FlightData.dme < 200000) && !var.FlightData.isINSMode())
                 {
                     var fB = NavUtilLib.Utils.CalcBearingTo(Utils.CalcRadiansFromDeg(var.FlightData.selectedRwy.gsLongitude - var.FlightData.currentVessel.longitude),
                                             Utils.CalcRadiansFromDeg(var.FlightData.currentVessel.latitude),
@@ -144,7 +144,7 @@ namespace NavUtilLib
 
                     var gsHorDev = Utils.CalcLocalizerDeviation(fB,var.FlightData.selectedRwy);
 
-                    if (Math.Abs(gsHorDev) < 25)
+                    if (!var.FlightData.isINSMode() && (Math.Abs(gsHorDev) < 25) && (var.FlightData.dme<12000))
                         gsFlag = false;
 
 

--- a/KSP Navigation/NavUtilLib/GlobalVariables.cs
+++ b/KSP Navigation/NavUtilLib/GlobalVariables.cs
@@ -148,7 +148,7 @@ namespace NavUtilLib
 		            	insTarget.isINSTarget = true;
 		            	insTarget.ident = waypoint.name;
 		            	insTarget.hdg = selectedRwy != null ? selectedRwy.hdg : 0;
-		            	insTarget.altMSL = (float)waypoint.altitude;
+		            	insTarget.altMSL = (float)(waypoint.height + waypoint.altitude);
 		            	insTarget.locLatitude = (float)navpoint.latitude;
 		            	insTarget.locLongitude = (float)navpoint.longitude;
 		            	insTarget.gsLatitude = (float)navpoint.latitude;

--- a/KSP Navigation/NavUtilLib/NavUtilLibHelper.cs
+++ b/KSP Navigation/NavUtilLib/NavUtilLibHelper.cs
@@ -168,18 +168,15 @@ namespace NavUtilLib
             //write text to screen
             //write runway info
 
-
-            if (rwyHover)
-                NavUtilLib.TextWriter.addTextToRT(screen, "→Runway: " + NavUtilLib.GlobalVariables.FlightData.selectedRwy.ident, new Vector2(20, screen.height - 40), NavUtilLib.GlobalVariables.Materials.Instance.whiteFont, .64f);
-            else
-                NavUtilLib.TextWriter.addTextToRT(screen, " Runway: " + NavUtilLib.GlobalVariables.FlightData.selectedRwy.ident, new Vector2(20, screen.height - 40), NavUtilLib.GlobalVariables.Materials.Instance.whiteFont, .64f);
-
-            if (gsHover)
-                NavUtilLib.TextWriter.addTextToRT(screen, "→Glideslope: " + string.Format("{0:F1}", NavUtilLib.GlobalVariables.FlightData.selectedGlideSlope) + "°  Elevation: " + string.Format("{0:F0}", NavUtilLib.GlobalVariables.FlightData.selectedRwy.altMSL) + "m", new Vector2(20, screen.height - 64), NavUtilLib.GlobalVariables.Materials.Instance.whiteFont, .64f);
-            else
-                NavUtilLib.TextWriter.addTextToRT(screen, " Glideslope: " + string.Format("{0:F1}", NavUtilLib.GlobalVariables.FlightData.selectedGlideSlope) + "°  Elevation: " + string.Format("{0:F0}", NavUtilLib.GlobalVariables.FlightData.selectedRwy.altMSL) + "m", new Vector2(20, screen.height - 64), NavUtilLib.GlobalVariables.Materials.Instance.whiteFont, .64f);
-
-
+            string runwayText = (var.FlightData.isINSMode() ? "INS" : "Runway") + ": " + NavUtilLib.GlobalVariables.FlightData.selectedRwy.ident;
+            string glideslopeText = var.FlightData.isINSMode() ? ""	: "Glideslope: " + string.Format("{0:F1}", NavUtilLib.GlobalVariables.FlightData.selectedGlideSlope) + "°  ";
+            string elevationText = (var.FlightData.isINSMode() ? "Alt MSL" : "Elevation") + ": " + string.Format("{0:F0}", NavUtilLib.GlobalVariables.FlightData.selectedRwy.altMSL) + "m";
+            
+            runwayText = (rwyHover ? "→" : " ") + runwayText;
+            glideslopeText = (gsHover ? "→" : " ") + glideslopeText;
+            
+	        NavUtilLib.TextWriter.addTextToRT(screen, runwayText, new Vector2(20, screen.height - 40), NavUtilLib.GlobalVariables.Materials.Instance.whiteFont, .64f);
+	        NavUtilLib.TextWriter.addTextToRT(screen, glideslopeText + elevationText, new Vector2(20, screen.height - 64), NavUtilLib.GlobalVariables.Materials.Instance.whiteFont, .64f);
 
             NavUtilLib.TextWriter.addTextToRT(screen, NavUtilLib.Utils.numberFormatter((float)NavUtilLib.Utils.makeAngle0to360(FlightGlobals.ship_heading), true).ToString(), new Vector2(584, screen.height - 102), NavUtilLib.GlobalVariables.Materials.Instance.whiteFont, .64f);
             NavUtilLib.TextWriter.addTextToRT(screen, NavUtilLib.Utils.numberFormatter((float)NavUtilLib.Utils.makeAngle0to360(NavUtilLib.GlobalVariables.FlightData.bearing), true).ToString(), new Vector2(584, screen.height - 131), NavUtilLib.GlobalVariables.Materials.Instance.whiteFont, .64f);
@@ -232,7 +229,7 @@ namespace NavUtilLib
                 closeHover = false;
 
 
-            if (GUI.Button(rwyBtn, new GUIContent("Next Runway", "rwyOn")))
+            if (GUI.Button(rwyBtn, new GUIContent("Next Runway", "rwyOn")) && !var.FlightData.isINSMode()) //doesn't let runway to be switched in INS mode
             {
                 if (Event.current.button == 0)
                 {

--- a/KSP Navigation/NavUtilLib/Runway.cs
+++ b/KSP Navigation/NavUtilLib/Runway.cs
@@ -40,5 +40,7 @@ namespace NavUtilLib
 
         //[KSPField]
         public float innerMarkerDist = 200;
+        
+        public bool isINSTarget = false; //true indicates that the runway is not the actual runway and is used as a target point for INS 
     }
 }


### PR DESCRIPTION
I've added INS (Inertial Navigation System) mode for HSI. That should make waypoint navigation in KSP more realistic than following some "baloons" in the air or an icon on the nav ball. 
INS mode is enabled as long as a waypoint is active in the game. To return to standard Localizer mode one needs to deactivate the waypoint.
This works with KSP versions that have FinePrint integrated.

INS mode has the following effects for the time it is enabled:
The "INS: " and the name of active waypoint is displayed instead of "Runway" on the top part of HSI.
Waypoint's Altitude MSL is displayed instead of Glideslope and Elevation.
Runway and glideslope switching is disabled.
The glideslope pointer is hidden.
The Localizer needle is hidden, the course is frozen to previous setting, so INS uses only NDB needle to show direction and DME to show distance to waypoint.

Don't know if you agree but I've also made ILS indication appear only within 12 km from runway. That's in the line 147 of GlobalV_DiplayData.

What is not implemented:
* You cannot switch waypoints by clicking HSI like it was with runways because in that case we'd have to mess with stock and Waypoint Manager's waypoint systems to keep things consistent among the mods. Instead we just use what is already set for us.
* I've tried to display latitude/longitude along with waypoint's altitude for more authenticity but strange KSP longitude values could only cause frustration.